### PR TITLE
config: enable 9P_FSCACHE

### DIFF
--- a/arch/x86/configs/clear_containers_defconfig
+++ b/arch/x86/configs/clear_containers_defconfig
@@ -1,3 +1,7 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Linux/x86 4.9.34-75.container Kernel Configuration
+#
 CONFIG_64BIT=y
 CONFIG_X86_64=y
 CONFIG_X86=y
@@ -1901,7 +1905,12 @@ CONFIG_OVERLAY_FS=y
 #
 # Caches
 #
-# CONFIG_FSCACHE is not set
+CONFIG_FSCACHE=y
+# CONFIG_FSCACHE_STATS is not set
+# CONFIG_FSCACHE_HISTOGRAM is not set
+# CONFIG_FSCACHE_DEBUG is not set
+# CONFIG_FSCACHE_OBJECT_LIST is not set
+# CONFIG_CACHEFILES is not set
 
 #
 # CD-ROM/DVD Filesystems
@@ -1943,6 +1952,7 @@ CONFIG_NETWORK_FILESYSTEMS=y
 # CONFIG_CODA_FS is not set
 # CONFIG_AFS_FS is not set
 CONFIG_9P_FS=y
+CONFIG_9P_FSCACHE=y
 CONFIG_9P_FS_POSIX_ACL=y
 CONFIG_9P_FS_SECURITY=y
 CONFIG_NLS=y


### PR DESCRIPTION
We need this config update in order to enable 9P mounts to be r/w. Today they are read only, which results in many failed container workloads.